### PR TITLE
chore: update backend URL from epi-backend-s14g to epi-backend

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,7 +1,7 @@
 # ===== PRODUCTION ENVIRONMENT =====
 # URL direta para produção
-VITE_API_BASE_URL=https://epi-backend-s14g.onrender.com/api
-VITE_BACKEND_BASE_URL=https://epi-backend-s14g.onrender.com
+VITE_API_BASE_URL=https://epi-backend.onrender.com/api
+VITE_BACKEND_BASE_URL=https://epi-backend.onrender.com
 VITE_ENVIRONMENT=production
 
 # ===== GOOGLE SERVICES =====

--- a/scripts/quick-check-avental.js
+++ b/scripts/quick-check-avental.js
@@ -7,7 +7,7 @@
 
 import https from 'https';
 
-const API_BASE = 'https://epi-backend-s14g.onrender.com/api';
+const API_BASE = 'https://epi-backend.onrender.com/api';
 
 async function makeRequest(url) {
   return new Promise((resolve, reject) => {
@@ -142,7 +142,7 @@ async function checkAventalConsistency() {
   } catch (error) {
     console.error('❌ ERRO:', error.message);
     console.log('\n🔧 VERIFICAÇÕES:');
-    console.log('1. Backend está rodando? https://epi-backend-s14g.onrender.com/health');
+    console.log('1. Backend está rodando? https://epi-backend.onrender.com/health');
     console.log('2. Dados foram importados corretamente?');
     console.log('3. Proxy está configurado? (npm run dev)');
   }

--- a/src/lib/components/containers/ColaboradorContainer.svelte
+++ b/src/lib/components/containers/ColaboradorContainer.svelte
@@ -25,7 +25,7 @@
       console.log('👥 Fetching colaboradores with params:', params);
       try {
         // Usar endpoint real de colaboradores
-        const response = await fetch(`https://epi-backend-s14g.onrender.com/api/colaboradores?page=${params.page || 1}&limit=${params.limit || 10}`, {
+        const response = await fetch(`https://epi-backend.onrender.com/api/colaboradores?page=${params.page || 1}&limit=${params.limit || 10}`, {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
@@ -86,7 +86,7 @@
       loadingContratadas = true;
       console.log('🏢 Carregando contratadas...');
       
-      const response = await fetch('https://epi-backend-s14g.onrender.com/api/contratadas', {
+      const response = await fetch('https://epi-backend.onrender.com/api/contratadas', {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/src/lib/services/core/apiClient.ts
+++ b/src/lib/services/core/apiClient.ts
@@ -12,7 +12,7 @@ import { browser } from "$app/environment";
 export const API_BASE_URL = (() => {
   if (typeof window === "undefined") {
     // SSR - usar URL direta sempre
-    return "https://epi-backend-s14g.onrender.com/api";
+    return "https://epi-backend.onrender.com/api";
   }
   
   const isLocal = window.location.hostname === "localhost" || 
@@ -25,11 +25,11 @@ export const API_BASE_URL = (() => {
   //   return "/api";
   // } else {
   //   // Produção, GitHub Pages ou qualquer outro ambiente - URL direta
-  //   return "https://epi-backend-s14g.onrender.com/api";
+  //   return "https://epi-backend.onrender.com/api";
   // }
   
   // URL direta sempre (contornando proxy problemático)
-  return "https://epi-backend-s14g.onrender.com/api";
+  return "https://epi-backend.onrender.com/api";
 })();
 
 // Interfaces para request unificado

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     host: true,
     proxy: {
       "/api": {
-        target: "https://epi-backend-s14g.onrender.com",
+        target: "https://epi-backend.onrender.com",
         changeOrigin: true,
         secure: true,
         configure: (proxy, options) => {


### PR DESCRIPTION
Atualiza todas as referências do backend para usar a nova URL https://epi-backend.onrender.com em vez de https://epi-backend-s14g.onrender.com